### PR TITLE
Fix assert in newlib on esp32

### DIFF
--- a/newlib/libc/stdlib/assert.c
+++ b/newlib/libc/stdlib/assert.c
@@ -59,7 +59,10 @@ __assert_func (const char *file,
 	   "assertion \"%s\" failed: file \"%s\", line %d%s%s\n",
 	   failedexpr, file, line,
 	   func ? ", function: " : "", func ? func : "");
+  #ifndef __XTENSA__
+  /* Xtensa has no abort implementation in stdlib, ignore it. */
   abort();
+  #endif /* __XTENSA__ */
   /* NOTREACHED */
 }
 #endif /* HAVE_ASSERT_FUNC */


### PR DESCRIPTION
When library has to use the `assert` in newlib instead of the builtin function (like what we found in `harfbuzz`). The compiler would raise an `undefined reference to abort` error as shown.

![photo_2020-05-04 9 12 50 PM](https://user-images.githubusercontent.com/2303500/80964541-07ef3f80-8e4c-11ea-9f44-c9979e407ccf.jpeg)

This is caused by lack of `abort` implementation in esp32's standard library. In this patch, I simply ignore it for passing the linking problem until we find a proper way to handle it with ASM.