### PR TITLE
xtensa/memcpy.S: Fix invalid asm code

### DIFF
--- a/newlib/libc/machine/xtensa/memcpy.S
+++ b/newlib/libc/machine/xtensa/memcpy.S
@@ -258,7 +258,7 @@ memcpy:
 	   unaligned src.  */
 	ssa8	a3		// set shift amount from byte offset
 #if UNALIGNED_ADDRESSES_CHECKED
-	srli    a11, a8, 30     // save unalignment offset for below
+	extui   a11, a8, 30, 2  // save unalignment offset for below
 	sub	a3, a3, a11	// align a3
 #endif
 	l32i	a6, a3, 0	// load first word


### PR DESCRIPTION
"srli a11, a8, 30" is invalid, srli shifts by 0 to 15 bits. Some assemblers (e.g. gas 2.40) automatically translate a srli statement with > 15 bit shift to an extui statement, some others (clang 16 with espressif patches) don't.

Using extui works with both.

Closes https://github.com/espressif/newlib-esp32/issues/11