### PR TITLE
Make libgloss buildable for Xtensa ESP8266

### DIFF
--- a/libgloss/xtensa/crt1-boards.S
+++ b/libgloss/xtensa/crt1-boards.S
@@ -46,8 +46,13 @@
 
 .type	main, @function
 
-# define CALL	call4
-# define CALLX	callx4
+# if __XCHAL_HAVE_WINDOWED
+#   define CALL	call4
+#   define CALLX	callx4
+# else  // __XCHAL_HAVE_WINDOWED
+#   define CALL	call0
+#   define CALLX	callx0
+# endif  // __XCHAL_HAVE_WINDOWED
 # define ARG1	a6	/* 1st outgoing call argument */
 # define ARG2	a7	/* 2nd outgoing call argument */
 # define ARG3	a8	/* 3rd outgoing call argument */
@@ -85,6 +90,7 @@ _start:
 	wsr	a0, INTENABLE	// INTENABLE value is not defined after reset.
 				//make sure that interrupts are shut off (*before* we lower PS.INTLEVEL and PS.EXCM!)
 
+# if __XCHAL_HAVE_WINDOWED
 	//  Windowed register init, so we can call windowed code (eg. C code).
 	movi	a1, 1
 	wsr	a1, WINDOWSTART
@@ -92,6 +98,7 @@ _start:
 	//  It resets WINDOWSTART to 1 starting with LX2.0/X7.0 (RB-2006.0).
 	//  However, assuming hard reset is not yet always practical, so do this anyway:
 	wsr	a0, WINDOWBASE
+# endif  // __XCHAL_HAVE_WINDOWED
 	rsync
 
 	// Set VECBASE to use our vectors instead vectors in ROM

--- a/libgloss/xtensa/crt1-sim.S
+++ b/libgloss/xtensa/crt1-sim.S
@@ -41,8 +41,13 @@
 .type	main, @function
 .type	exit, @function
 
-# define CALL	call4
-# define CALLX	callx4
+# if __XCHAL_HAVE_WINDOWED
+#   define CALL	call4
+#   define CALLX	callx4
+# else  // __XCHAL_HAVE_WINDOWED
+#   define CALL	call0
+#   define CALLX	callx0
+# endif  // __XCHAL_HAVE_WINDOWED
 # define ARG1	a6	/* 1st outgoing call argument */
 # define ARG2	a7	/* 2nd outgoing call argument */
 # define ARG3	a8	/* 3rd outgoing call argument */
@@ -82,6 +87,7 @@ _start:
 	wsr	a0, INTENABLE	// INTENABLE value is not defined after reset.
 				//make sure that interrupts are shut off (*before* we lower PS.INTLEVEL and PS.EXCM!)
 
+# if __XCHAL_HAVE_WINDOWED
 	//  Windowed register init, so we can call windowed code (eg. C code).
 	movi	a1, 1
 	wsr	a1, WINDOWSTART
@@ -89,6 +95,7 @@ _start:
 	//  It resets WINDOWSTART to 1 starting with LX2.0/X7.0 (RB-2006.0).
 	//  However, assuming hard reset is not yet always practical, so do this anyway:
 	wsr	a0, WINDOWBASE
+# endif  // __XCHAL_HAVE_WINDOWED
 	rsync
 
 	// Set VECBASE to use our vectors instead vectors in ROM


### PR DESCRIPTION
## Description

This is needed before `espressif/crosstool-NG` can build for ESP8266.

## Related

Fixes #14.

See the [originating discussion](https://github.com/espressif/crosstool-NG/issues/88) in particular [this comment](https://github.com/espressif/crosstool-NG/issues/88#issuecomment-4038147305).

## Testing

Having checked out `espressif/crosstool-NG` and applied the other changes in the above comment:

```
./bootstrap
./configure --enable-local
make
./ct-ng xtensa-esp-elf
./ct-ng build
```

Before this change:

```
[INFO ]  Installing C library
[EXTRA]    Configuring C library
[EXTRA]    Building C library
[ERROR]    /Users/george/src/espressif-crosstool-NG/.build/xtensa-esp-elf/src/newlib/libgloss/xtensa/crt1-boards.S:90: Error: invalid register 'WINDOWSTART' for 'wsr' instruction
[ERROR]    /Users/george/src/espressif-crosstool-NG/.build/xtensa-esp-elf/src/newlib/libgloss/xtensa/crt1-boards.S:94: Error: invalid register 'WINDOWBASE' for 'wsr' instruction
[ERROR]    /Users/george/src/espressif-crosstool-NG/.build/xtensa-esp-elf/src/newlib/libgloss/xtensa/crt1-boards.S:144: Error: unknown opcode or format name 'callx4'
[ERROR]    /Users/george/src/espressif-crosstool-NG/.build/xtensa-esp-elf/src/newlib/libgloss/xtensa/crt1-boards.S:156: Error: unknown opcode or format name 'call4'
[ERROR]    /Users/george/src/espressif-crosstool-NG/.build/xtensa-esp-elf/src/newlib/libgloss/xtensa/crt1-boards.S:162: Error: unknown opcode or format name 'callx4'
[ERROR]    /Users/george/src/espressif-crosstool-NG/.build/xtensa-esp-elf/src/newlib/libgloss/xtensa/crt1-boards.S:177: Error: unknown opcode or format name 'call4'
[ERROR]    /Users/george/src/espressif-crosstool-NG/.build/xtensa-esp-elf/src/newlib/libgloss/xtensa/crt1-boards.S:196: Error: unknown opcode or format name 'call4'
[ERROR]    /Users/george/src/espressif-crosstool-NG/.build/xtensa-esp-elf/src/newlib/libgloss/xtensa/crt1-boards.S:203: Error: unknown opcode or format name 'call4'
[ERROR]    /Users/george/src/espressif-crosstool-NG/.build/xtensa-esp-elf/src/newlib/libgloss/xtensa/crt1-boards.S:205: Error: unknown opcode or format name 'call4'
[ERROR]    /Users/george/src/espressif-crosstool-NG/.build/xtensa-esp-elf/src/newlib/libgloss/xtensa/crt1-sim.S:87: Error: invalid register 'WINDOWSTART' for 'wsr' instruction
[ERROR]    /Users/george/src/espressif-crosstool-NG/.build/xtensa-esp-elf/src/newlib/libgloss/xtensa/crt1-sim.S:91: Error: invalid register 'WINDOWBASE' for 'wsr' instruction
[ERROR]    /Users/george/src/espressif-crosstool-NG/.build/xtensa-esp-elf/src/newlib/libgloss/xtensa/crt1-sim.S:190: Error: unknown opcode or format name 'call4'
[ERROR]    /Users/george/src/espressif-crosstool-NG/.build/xtensa-esp-elf/src/newlib/libgloss/xtensa/crt1-sim.S:194: Error: unknown opcode or format name 'call4'
[ERROR]    /Users/george/src/espressif-crosstool-NG/.build/xtensa-esp-elf/src/newlib/libgloss/xtensa/crt1-sim.S:197: Error: unknown opcode or format name 'call4'
[ERROR]    make[10]: *** [xtensa/crt1-boards.o] Error 1
[ERROR]    make[10]: *** Waiting for unfinished jobs....
[ERROR]    make[10]: *** [xtensa/crt1-sim.o] Error 1
[ERROR]    make[9]: *** [all-recursive] Error 1
[ERROR]    make[8]: *** [all] Error 2
[ERROR]    make[7]: *** [multi-do] Error 1
[ERROR]    make[6]: *** [all-multi] Error 2
[ERROR]    make[5]: *** [all-recursive] Error 1
[ERROR]    make[4]: *** [all] Error 2
[ERROR]    make[3]: *** [all-target-libgloss] Error 2
[ERROR]    make[2]: *** [all] Error 2
```

After this change: no build error.

I don't have any ESP32-based hardware to check that the existing multilib configurations still work. However, I have used `hexdump -C` and `objdump -D -g` to diff the various configurations' `crt1-boards.o` and `crt1-sim.o` files against the corresponding object files in a clean baseline build, and found that the only differences are in the debug information because the line numbering has changed.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [X] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [X] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.
