### PR TITLE
libgloss: zero-initialize struct stat in _fstat for ESP targets

### DIFF
--- a/libgloss/riscv/esp/syscalls.c
+++ b/libgloss/riscv/esp/syscalls.c
@@ -1,6 +1,7 @@
 #include <unistd.h>
 #include <time.h>
 #include <sys/stat.h>
+#include <string.h>
 #include <reent.h>
 #include "esp_board.h"
 #include "config.h"
@@ -11,6 +12,7 @@ _fstat(int file, struct stat *st)
 {
     if (file <= STDERR_FILENO)
     {
+        memset(st, 0, sizeof(*st));
         st->st_mode = S_IFCHR;
         return  0;
     }

--- a/libgloss/xtensa/syscalls.c
+++ b/libgloss/xtensa/syscalls.c
@@ -6,6 +6,7 @@
 #include <unistd.h>
 #include <syscalls.h>
 #include <sys/stat.h>
+#include <string.h>
 #include <soc/uart.h>
 
 #if defined (OPENOCD_SEMIHOSTING) || (QEMU_SEMIHOSTING)
@@ -145,6 +146,7 @@ _fstat (int fd, struct stat *pstat)
 
     if (fd < STDERR_FILENO)
     {
+        memset(pstat, 0, sizeof(*pstat));
         pstat->st_mode = S_IFCHR;
         return  0;
     }


### PR DESCRIPTION
Fixes #17

### Summary
Initialize the whole `struct stat` in `_fstat` success path for ESP targets, then set `st_mode`.

### Why
`__swhatbuf_r` may read fields such as `st_blksize` after `_fstat_r` returns success. If target `_fstat` only sets `st_mode`, uninitialized fields can leak into stdio buffer sizing logic.

### Changes
- `libgloss/riscv/esp/syscalls.c`: add `memset(st, 0, sizeof(*st));` before setting `st_mode`
- `libgloss/xtensa/syscalls.c`: add `memset(pstat, 0, sizeof(*pstat));` before setting `st_mode`
- include `<string.h>` in both files

### Notes
- This follows reviewer guidance to zero-initialize the whole struct to avoid future issues.
- Existing fd gating conditions are preserved; this change only affects initialization safety.